### PR TITLE
Revert "fix(helm): update chart grafana to 6.55.1"

### DIFF
--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: grafana
-      version: 6.55.1
+      version: 6.55.0
       sourceRef:
         kind: HelmRepository
         name: grafana


### PR DESCRIPTION
Reverts osnabrugge/home-ops#111

No dashboards since updating to 6.55.1.  Getting the following error:

Failed to establish a new connection: [Errno 111] Connection refused')': /api/admin/provisioning/dashboards/reload