### PR TITLE
Revert "feat(container)!: Update image ghcr.io/k8snetworkplumbingwg/multus-cni to v4"

### DIFF
--- a/kubernetes/apps/networking/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/multus/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
   values:
     image:
       repository: ghcr.io/k8snetworkplumbingwg/multus-cni
-      tag: v4.0.1
+      tag: v3.9.3
       pullPolicy: Always
 
     tolerations:


### PR DESCRIPTION
Reverts osnabrugge/home-ops#137

Helm Chart needs to be updated to support 4.0 and greater