### PR TITLE
Revert "feat(container): update image ghcr.io/onedr0p/kopia to v0.13.0"

### DIFF
--- a/kubernetes/apps/default/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/default/kopia/app/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
   values:
     initContainers:
       wait-for-repo:
-        image: ghcr.io/onedr0p/kopia:0.13.0@sha256:1b0f77c7851f7d948c63e4f05af0e24b3efcd6d7266b7b1ce59d2d43138d08f5
+        image: ghcr.io/onedr0p/kopia:0.12.1@sha256:4ee9bc68299481fced34899eaec8bd42a6c9e5db902c6bef61ba0b0094b25b3b
         command:
           - /bin/bash
           - -c
@@ -39,7 +39,7 @@ spec:
             mountPath: /snapshots
     image:
       repository: ghcr.io/onedr0p/kopia
-      tag: 0.13.0@sha256:1b0f77c7851f7d948c63e4f05af0e24b3efcd6d7266b7b1ce59d2d43138d08f5
+      tag: 0.12.1@sha256:4ee9bc68299481fced34899eaec8bd42a6c9e5db902c6bef61ba0b0094b25b3b
     env:
       KOPIA_PASSWORD: "none"
     command: kopia

--- a/kubernetes/apps/kyverno/kyverno/policies/snapshot-cronjob-controller.yaml
+++ b/kubernetes/apps/kyverno/kyverno/policies/snapshot-cronjob-controller.yaml
@@ -90,12 +90,12 @@ spec:
                     # Stagger jobs to run randomly within X seconds to avoid bringing down all apps at once
                     initContainers:
                       - name: wait
-                        image: ghcr.io/onedr0p/kopia:0.13.0@sha256:1b0f77c7851f7d948c63e4f05af0e24b3efcd6d7266b7b1ce59d2d43138d08f5
+                        image: ghcr.io/onedr0p/kopia:0.12.1@sha256:4ee9bc68299481fced34899eaec8bd42a6c9e5db902c6bef61ba0b0094b25b3b
                         command: ["/scripts/sleep.sh"]
                         args: ["1", "900"]
                     containers:
                       - name: snapshot
-                        image: ghcr.io/onedr0p/kopia:0.13.0@sha256:1b0f77c7851f7d948c63e4f05af0e24b3efcd6d7266b7b1ce59d2d43138d08f5
+                        image: ghcr.io/onedr0p/kopia:0.12.1@sha256:4ee9bc68299481fced34899eaec8bd42a6c9e5db902c6bef61ba0b0094b25b3b
                         env:
                           - name: KOPIA_CACHE_DIRECTORY
                             value: /snapshots/{{ namespace }}/{{ appName }}/{{ claimName }}/cache


### PR DESCRIPTION
Reverts osnabrugge/home-ops#147

Getting startup error (may have broken the ability to run insecure)

kopia: error: unknown long flag '--insecure', try --help